### PR TITLE
adjusted the topnav height

### DIFF
--- a/src/app/(dashboard)/components/TopNav.tsx
+++ b/src/app/(dashboard)/components/TopNav.tsx
@@ -31,7 +31,7 @@ const TopNav = ({ onMenuClick }: TopNavProps) => {
     <Flex
       justifyContent={'space-between'}
       alignItems={'center'}
-      h={'6.25rem'}
+      h={{ base: '5rem', md: '6.25rem' }}
       px={'2rem'}
     >
       <Flex alignItems="center" gap={4}>

--- a/src/app/(dashboard)/services/components/BankServiceList.tsx
+++ b/src/app/(dashboard)/services/components/BankServiceList.tsx
@@ -18,6 +18,7 @@ const BankServiceList = () => {
             bg={'#ffffffff'}
             p={5}
             borderRadius={'3xl'}
+            boxShadow={'md'}
           >
             <Flex gap={5}>
               <Image src={service.imageOne} alt="icon" width={60} height={60} />

--- a/src/app/(dashboard)/services/components/BaseBankServiceList.tsx
+++ b/src/app/(dashboard)/services/components/BaseBankServiceList.tsx
@@ -19,6 +19,7 @@ const BaseBankServiceList = () => {
             bg={'#ffffffff'}
             p={2}
             borderRadius={'3xl'}
+            boxShadow={'md'}
           >
             <Flex gap={5}>
               <Image src={service.imageOne} alt="icon" width={45} height={20} />


### PR DESCRIPTION
## Summary by Sourcery

Enhance the TopNav component to have a responsive height and add visual depth to the BankServiceList and BaseBankServiceList components by including a medium box shadow.

Enhancements:
- Adjust the TopNav component height to be responsive, with a base height of 5rem and a medium screen height of 6.25rem.
- Add a medium box shadow to the BankServiceList and BaseBankServiceList components for improved visual depth.