### PR TITLE
change the env

### DIFF
--- a/src/lib/features/api.slice.ts
+++ b/src/lib/features/api.slice.ts
@@ -7,7 +7,7 @@ import {
   fetchBaseQuery,
 } from "@reduxjs/toolkit/query/react";
 
-const BASE_URL = process.env.BASE_URL || 'https://adeniran1234.pythonanywhere.com';
+const BASE_URL = process.env.BACKEND_GENERAL_URL;
 
 const baseQuery = fetchBaseQuery({
   baseUrl: BASE_URL,


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Switch from using BASE_URL to BACKEND_GENERAL_URL for the base URL of API calls.